### PR TITLE
Modify SCSS so that the separators are distributed evenly

### DIFF
--- a/projects/password-strength-meter/src/lib/password-strength-meter.component.scss
+++ b/projects/password-strength-meter/src/lib/password-strength-meter.component.scss
@@ -16,16 +16,16 @@
   border-style: solid;
   border-width: 0 5px 0 5px;
   position: absolute;
-  width: 85px;
+  width: 20%;
   z-index: 10;
 }
 
 .strength-meter:before {
-  left: 70px;
+  left: 20%;
 }
 
 .strength-meter:after {
-  right: 70px;
+  right: 20%;
 }
 
 .strength-meter-fill {


### PR DESCRIPTION
It seems like the separators (the 4 white dots) are designed to be distributed
evenly when the width of the whole component is 400px, but for other widths,
it looks very arbitrary and can give some pretty ugly effects on very small screens.

This fixes these issues by simply making small changes to `password-strength-meter.component.scss` so that they are distributed with a width of 20% of the whole width. 